### PR TITLE
feat(ci): add build workflow for go-templ-tailwindcss image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,31 @@
+name: build
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build-base:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        container: ["go-templ-tailwindcss"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Buildah Base Images
+        id: build-base
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: builder
+          tags: ${{ matrix.container }}
+          oci: true
+          containerfiles: |
+            Dockerfile.${{ matrix.container }}
+      - name: Push Base To ghcr
+        id: push-base-to-docker
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-base.outputs.image }}
+          tags: ${{ steps.build-base.outputs.tags }}
+          registry: "ghcr.io/wp-ci"
+          username: "naicoi92"
+          password: ${{ secrets.GH_TOKEN }}

--- a/Dockerfile.go-templ-tailwindcss
+++ b/Dockerfile.go-templ-tailwindcss
@@ -1,0 +1,6 @@
+FROM golang:1.24-alpine
+RUN go install github.com/a-h/templ/cmd/templ@latest
+RUN go install github.com/a-h/templ/cmd/templ-tailwindcss@latest
+RUN curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64
+RUN chmod +x tailwindcss-linux-x64
+RUN mv tailwindcss-linux-x64 /usr/local/bin/tailwindcss


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow to build and push a
Docker image for the `go-templ-tailwindcss` container. The workflow is
triggered on pushes to the `main` branch and uses the Buildah action to
build the image and the Push to Registry action to push it to the
`ghcr.io/wp-ci` repository.

The `Dockerfile.go-templ-tailwindcss` file is also added, which
installs the necessary dependencies for the `templ` and
`templ-tailwindcss` tools, as well as the Tailwind CSS CLI.