### PR TITLE
feat(Dockerfile): Install Templ and Tailwind CLI

### DIFF
--- a/Dockerfile.go-templ-tailwindcss
+++ b/Dockerfile.go-templ-tailwindcss
@@ -1,6 +1,5 @@
 FROM golang:1.24-alpine
 RUN go install github.com/a-h/templ/cmd/templ@latest
-RUN go install github.com/a-h/templ/cmd/templ-tailwindcss@latest
 RUN curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64
 RUN chmod +x tailwindcss-linux-x64
 RUN mv tailwindcss-linux-x64 /usr/local/bin/tailwindcss


### PR DESCRIPTION
Installs the latest versions of the Templ and Tailwind CLI tools in the
Docker image. This allows the image to be used for building and
compiling Go templates with Tailwind CSS support.