### PR TITLE
feat: Add curl to the Go Dockerfile for Templ and Tailwind

### DIFF
--- a/Dockerfile.go-templ-tailwindcss
+++ b/Dockerfile.go-templ-tailwindcss
@@ -1,4 +1,5 @@
 FROM golang:1.24-alpine
+RUN apk add --no-cache curl
 RUN go install github.com/a-h/templ/cmd/templ@latest
 RUN curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64
 RUN chmod +x tailwindcss-linux-x64


### PR DESCRIPTION
Adds the curl package to the Go Dockerfile to enable downloading the
Tailwind CSS binary. This is necessary for the build process to
function correctly.