### PR TITLE
feat: Add storage and container configuration files

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        container: ["go-templ-tailwindcss"]
+        container:
+          - "buildah"
+          - "go-templ-tailwindcss"
     steps:
       - uses: actions/checkout@v4
       - name: Buildah Base Images

--- a/Dockerfile.buildah
+++ b/Dockerfile.buildah
@@ -1,0 +1,15 @@
+FROM alpine
+LABEL "io.containers.capabilities"="CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,SYS_CHROOT"
+
+RUN set -xeuf; \
+  apk add --no-cache buildah fuse-overlayfs; \
+  adduser -D build; \
+  echo -e "build:1:999\nbuild:1001:64535" > /etc/subuid; \
+  echo -e "build:1:999\nbuild:1001:64535" > /etc/subgid; \
+  :
+
+COPY storage.conf containers.conf /etc/containers/
+
+USER build
+
+ENV BUILDAH_ISOLATION=chroot HOME=/home/build USER=build LOGNAME=build

--- a/containers.conf
+++ b/containers.conf
@@ -1,0 +1,2 @@
+[engine]
+cgroup_manager = "cgroupfs"

--- a/storage.conf
+++ b/storage.conf
@@ -1,0 +1,6 @@
+[storage]
+driver = "vfs"
+runroot = "/run/containers/storage"
+graphroot = "/var/lib/containers/storage"
+[storage.options]
+pull_options = {enable_partial_images = "false", use_hard_links = "false", ostree_repos=""}


### PR DESCRIPTION
    
Add a new `storage.conf` file to configure the container storage
driver, runroot, and graphroot. Also add a new `containers.conf`
file to configure the cgroup manager.

These changes are necessary to ensure the container build process
works correctly and uses the desired storage and cgroup
configurations.