### PR TITLE
feat: Add Tailwind CSS binary to /usr/bin

### DIFF
--- a/Dockerfile.go-templ-tailwindcss
+++ b/Dockerfile.go-templ-tailwindcss
@@ -3,4 +3,4 @@ RUN apk add --no-cache curl
 RUN go install github.com/a-h/templ/cmd/templ@latest
 RUN curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64
 RUN chmod +x tailwindcss-linux-x64
-RUN mv tailwindcss-linux-x64 /usr/local/bin/tailwindcss
+RUN mv tailwindcss-linux-x64 /usr/bin/tailwindcss


### PR DESCRIPTION
Adds the Tailwind CSS binary to the /usr/bin directory instead of
/usr/local/bin. This change ensures that the Tailwind CSS binary is
available in the system's default binary directory, making it more
accessible for use in the project.